### PR TITLE
Add constructor to prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ a low memory footprint in mind. Check out the
 [demo](https://eugene-eeo.github.io/octopi/demo.html).
 
 ```js
-var oct = Octopi(['bird', 'boy']);
+var oct = new Octopi(['bird', 'boy']);
 oct.add('bid', {'word': 'BID'});
 oct.get('bi');   // => ['bird', {'word':'BID'}]
 ```

--- a/octopi.js
+++ b/octopi.js
@@ -8,6 +8,7 @@ Octopi = function(words) {
 };
 
 Octopi.prototype = {
+  constructor: Octopi,
   add: function(key, data) {
     var id = ++this.uid;
     var sub = this.tree;

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,13 @@ describe('Octopi(words)', function() {
   });
 });
 
+describe('Octopi constructor', function() {
+  it('returns the constructor function', function() {
+    var o = new Octopi();
+    assert.deepEqual(o.constructor, Octopi);
+  });
+});
+
 describe('Octopi.add', function() {
   it('allows arbitrary data to be added', function() {
     var o = new Octopi();


### PR DESCRIPTION
- Add the missing constructor to the prototype, along with a test
- Fix the README to correctly initialise an instance of Octopi
